### PR TITLE
Move appcompat support lib dependency declaration into plugin.xml.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,6 +47,7 @@
     </config-file>
 
     <framework src="src/android/mapbox.gradle" custom="true" type="gradleReference"/>
+    <framework src="com.android.support:appcompat-v7:22.+" />
     <source-file src="src/android/Mapbox.java" target-dir="src/com/telerik/plugins/mapbox"/>
 
     <resource-file src="src/android/libs/lost-1.0.1.jar" target="libs/lost-1.0.1.jar" />

--- a/src/android/mapbox.gradle
+++ b/src/android/mapbox.gradle
@@ -1,6 +1,5 @@
 ext.cdvMinSdkVersion = 15
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:22.+'
     compile('com.mapbox.mapboxsdk:mapbox-android-sdk:2.1.0@aar')
 }


### PR DESCRIPTION
Pretty minor but nice for consistency. The same could probably be done for the Mapbox GL SDK dependency too.