### PR TITLE
Android backbutton handling issue

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -44,6 +44,12 @@
 <script>
   var zoom = 10;
 
+  document.addEventListener("backbutton", onBackKeyDown, false);
+
+  function onBackKeyDown() {
+    alert('back button pressed');
+  }
+
   function setCenter() {
     Mapbox.setCenter({
       'lat': 50.2222,

--- a/src/android/Mapbox.java
+++ b/src/android/Mapbox.java
@@ -8,6 +8,8 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.util.DisplayMetrics;
 import android.view.ViewGroup;
+import android.view.KeyEvent;
+import android.view.View;
 import android.widget.FrameLayout;
 
 import com.mapbox.mapboxsdk.camera.CameraPosition;
@@ -178,7 +180,23 @@ public class Mapbox extends CordovaPlugin {
             FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(webViewWidth - left - right, webViewHeight - top - bottom);
             params.setMargins(left, top, right, bottom);
             mapView.setLayoutParams(params);
+			//@anothar we have to override back button or app will just close
+            mapView.setOnKeyListener(new View.OnKeyListener() {
+              @Override
+              public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (Integer.parseInt(android.os.Build.VERSION.SDK) > 5
+                        && keyCode == KeyEvent.KEYCODE_BACK
+                        && event.getRepeatCount() == 0) {
 
+                  if(event.getAction()!=KeyEvent.ACTION_DOWN)
+                  {
+                    webView.getEngine().loadUrl("javascript:cordova.fireDocumentEvent('backbutton');",false);
+                  }
+                  return true;
+                }
+                return false;
+              }
+            });
             layout.addView(mapView);
             callbackContext.success();
           }

--- a/src/android/Mapbox.java
+++ b/src/android/Mapbox.java
@@ -51,6 +51,7 @@ public class Mapbox extends CordovaPlugin {
 
   private static final String ACTION_SHOW = "show";
   private static final String ACTION_HIDE = "hide";
+  private static final String ACTION_ADD_BACKBUTTON_CALLBACK = "addBackButtonCallback";
   private static final String ACTION_ADD_MARKERS = "addMarkers";
   private static final String ACTION_REMOVE_ALL_MARKERS = "removeAllMarkers";
   private static final String ACTION_ADD_MARKER_CALLBACK = "addMarkerCallback";
@@ -78,6 +79,7 @@ public class Mapbox extends CordovaPlugin {
   private String accessToken;
   private CallbackContext callback;
   private CallbackContext markerCallbackContext;
+  private CallbackContext backbuttonCallbackContext;
 
   private boolean showUserLocation;
 
@@ -180,23 +182,6 @@ public class Mapbox extends CordovaPlugin {
             FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(webViewWidth - left - right, webViewHeight - top - bottom);
             params.setMargins(left, top, right, bottom);
             mapView.setLayoutParams(params);
-			//@anothar we have to override back button or app will just close
-            mapView.setOnKeyListener(new View.OnKeyListener() {
-              @Override
-              public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (Integer.parseInt(android.os.Build.VERSION.SDK) > 5
-                        && keyCode == KeyEvent.KEYCODE_BACK
-                        && event.getRepeatCount() == 0) {
-
-                  if(event.getAction()!=KeyEvent.ACTION_DOWN)
-                  {
-                    webView.getEngine().loadUrl("javascript:cordova.fireDocumentEvent('backbutton');",false);
-                  }
-                  return true;
-                }
-                return false;
-              }
-            });
             layout.addView(mapView);
             callbackContext.success();
           }
@@ -411,6 +396,11 @@ public class Mapbox extends CordovaPlugin {
         this.markerCallbackContext = callbackContext;
         mapView.setOnInfoWindowClickListener(new MarkerClickListener());
 
+      } else if(ACTION_ADD_BACKBUTTON_CALLBACK.equals(action)){
+        if (mapView != null) {
+          mapView.setOnKeyListener(new BackbuttonListener(callbackContext));
+        }
+
       } else if (ACTION_ON_REGION_WILL_CHANGE.equals(action)) {
         if (mapView != null) {
           mapView.addOnMapChangedListener(new RegionWillChangeListener(callbackContext));
@@ -444,6 +434,30 @@ public class Mapbox extends CordovaPlugin {
       mo.snippet(marker.isNull("subtitle") ? null : marker.getString("subtitle"));
       mo.position(new LatLng(marker.getDouble("lat"), marker.getDouble("lng")));
       mapView.addMarker(mo);
+    }
+  }
+
+  private class BackbuttonListener implements View.OnKeyListener {
+    private CallbackContext callback;
+
+    public BackbuttonListener(CallbackContext providedCallback) {
+      this.callback = providedCallback;
+    }
+
+    @Override
+    public void onKey(View v, int keyCode, KeyEvent event) {
+      if ( Integer.parseInt(android.os.Build.VERSION.SDK) > 5 && keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0 ) {
+
+        if ( event.getAction() != KeyEvent.ACTION_DOWN ) {
+          PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+          pluginResult.setKeepCallback(true);
+          callback.sendPluginResult(pluginResult);
+        }
+
+        return true;
+      }
+
+      return false;
     }
   }
 

--- a/www/Mapbox.js
+++ b/www/Mapbox.js
@@ -1,12 +1,21 @@
 var exec = require("cordova/exec");
 
 module.exports = {
+  defaultBackButtonAction: function () {
+    cordova.fireDocumentEvent('backbutton', {});
+  },
+
   show: function (options, successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, "Mapbox", "show", [options]);
+    this.addBackButtonCallback(this.defaultBackButtonAction);
   },
 
   hide: function (options, successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, "Mapbox", "hide", [options]);
+  },
+
+  addBackButtonCallback: function(callback){
+    cordova.exec(callback, null, "Mapbox", "addBackButtonCallback", []);
   },
 
   addMarkers: function (options, successCallback, errorCallback) {


### PR DESCRIPTION
This needs to be reviewed, moved aside from the #42.

@anothar I had issues before with the `addMarkerCallback` because of the way it is designed to work (by a class shared variable).

Will let this aside for us to think on a better way to implement it.

The first idea that comes into my mind is to implement an event dispatcher natively on each map creation that is bind to a Map instance on the JS side. This would make future implementations easier, but not sure how difficult it could be ti implement.