### PR TITLE
Fix marker callback global issue

### DIFF
--- a/src/android/Mapbox.java
+++ b/src/android/Mapbox.java
@@ -190,9 +190,14 @@ public class Mapbox extends CordovaPlugin {
             @Override
             public void run() {
               ViewGroup vg = (ViewGroup) mapView.getParent();
+
               if (vg != null) {
                 vg.removeView(mapView);
               }
+
+              // Remove marker callback handler
+              this.markerCallbackContext = null;
+
               callbackContext.success();
             }
           });

--- a/src/ios/CDVMapbox.m
+++ b/src/ios/CDVMapbox.m
@@ -86,6 +86,9 @@
 - (void) hide:(CDVInvokedUrlCommand*)command {
   [_mapView removeFromSuperview];
 
+  // Remove marker callback handler
+  self.markerCallbackId = nil
+
   CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }


### PR DESCRIPTION
Fixes issue described by me at #67

> It happened with me, since markerCallback does sit under a global space instead of a map instance, it will sit there until we change. I have two kinds of maps on the project I'm using it. The first one does have markers and I need the callback for navigation. The second one is a location dragger, it has only one map, you move the map anywhere, it places the marker always in the middle (since we don't have dragged markers) and this allows me to give the user a way to choose a location. The issue was, whenever an user clicked on the second map's marker, it tried to execute things from the first one. I've workaround it by placing a noop js function () => {} whenever the first map was destroyed. The solution is to keep callbacks only during while the map view is opened.
